### PR TITLE
Makes aws-lc-rs vs ring configurable via features

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -18,9 +18,9 @@ rustls-pki-types =  { version = "1.11.0" }
 rustls-webpki = { version = "0.103.1", default-features = false, features = ["std"] }
 
 [features]
-default = ["crypto-ring"]
+default = []
 crypto-ring = ["rustls/ring", "rustls-webpki/ring"]
-crypto-aws-lc-rs = ["rustls/aws-lc-rs", "rustls-webpki/aws-lc-rs"]
+crypto-aws-lc-rs = ["rustls/aws_lc_rs", "rustls-webpki/aws-lc-rs"]
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sfio-rustls-config"
-version = "0.3.2"
+version = "0.4.0"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 description = "Configuration routines for Rustls used in libraries from Step Function I/O"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -13,9 +13,14 @@ rust-version = "1.74"
 pem = { version = "^3.0" }
 pkcs8 = { version = "0.10.2", features = ["encryption", "pkcs5", "pem", "std"] }
 rx509 = "^0.2"
-rustls = { version = "0.23", default-features = false, features = ["std", "logging", "tls12", "aws-lc-rs"] }
+rustls = { version = "0.23", default-features = false, features = ["std", "logging", "tls12"] }
 rustls-pki-types =  { version = "1.11.0" }
-rustls-webpki = { version = "0.103.1", default-features = false, features = ["std", "aws-lc-rs"] }
+rustls-webpki = { version = "0.103.1", default-features = false, features = ["std"] }
+
+[features]
+default = ["crypto-ring"]
+crypto-ring = ["rustls/ring", "rustls-webpki/ring"]
+crypto-aws-lc-rs = ["rustls/aws-lc-rs", "rustls-webpki/aws-lc-rs"]
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -13,8 +13,8 @@ rust-version = "1.74"
 pem = { version = "^3.0" }
 pkcs8 = { version = "0.10.2", features = ["encryption", "pkcs5", "pem", "std"] }
 rx509 = "^0.2"
-rustls = { version = "0.23", default-features = false, features = ["std", "logging", "tls12", "ring"] }
-rustls-webpki = { version = "0.102", default-features = false, features = ["std", "ring"] }
+rustls = { version = "0.23", default-features = false, features = ["std", "logging", "tls12", "aws-lc-rs"] }
+rustls-webpki = { version = "0.102.8", default-features = false, features = ["std", "aws_lc_rs"] }
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -14,7 +14,8 @@ pem = { version = "^3.0" }
 pkcs8 = { version = "0.10.2", features = ["encryption", "pkcs5", "pem", "std"] }
 rx509 = "^0.2"
 rustls = { version = "0.23", default-features = false, features = ["std", "logging", "tls12", "aws-lc-rs"] }
-rustls-webpki = { version = "0.102.8", default-features = false, features = ["std", "aws_lc_rs"] }
+rustls-pki-types =  { version = "1.11.0" }
+rustls-webpki = { version = "0.103.1", default-features = false, features = ["std", "aws-lc-rs"] }
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/lib/src/common_name.rs
+++ b/lib/src/common_name.rs
@@ -1,5 +1,5 @@
 use rustls::{CertificateError, Error};
-use webpki::types::{CertificateDer, ServerName};
+use rustls_pki_types::{CertificateDer, ServerName};
 
 pub(crate) fn verify_name_from_subject(
     end_entity: &CertificateDer,

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,10 +1,16 @@
 #![doc = include_str!("../README.md")]
 
 #[cfg(all(feature = "crypto-ring", feature = "crypto-aws-lc-rs"))]
-compile_error!("Features 'cryto-ring' and 'cryto-aws-lc-rs' are mutually exclusive and cannot be enabled together");
+compile_error!("Features 'crypto-ring' and 'crypto-aws-lc-rs' are mutually exclusive and cannot be enabled together");
 
 #[cfg(not(any(feature = "crypto-ring", feature = "crypto-aws-lc-rs")))]
-compile_error!("'cryto-ring' OR 'cryto-aws-lc-rs' must be enabled");
+compile_error!("'crypto-ring' OR 'crypto-aws-lc-rs' must be enabled");
+
+#[cfg(feature = "crypto-ring")]
+pub(crate) use rustls::crypto::ring::default_provider as default_crypto_provider;
+
+#[cfg(feature = "crypto-aws-lc-rs")]
+pub(crate) use rustls::crypto::aws_lc_rs::default_provider as default_crypto_provider;
 
 /// Client configurations
 pub mod client;

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,5 +1,11 @@
 #![doc = include_str!("../README.md")]
 
+#[cfg(all(feature = "crypto-ring", feature = "crypto-aws-lc-rs"))]
+compile_error!("Features 'cryto-ring' and 'cryto-aws-lc-rs' are mutually exclusive and cannot be enabled together");
+
+#[cfg(not(any(feature = "crypto-ring", feature = "crypto-aws-lc-rs")))]
+compile_error!("'cryto-ring' OR 'cryto-aws-lc-rs' must be enabled");
+
 /// Client configurations
 pub mod client;
 /// Server configurations

--- a/lib/src/name.rs
+++ b/lib/src/name.rs
@@ -5,7 +5,7 @@
 pub enum ServerNameVerification {
     /// Only verify the server's name from the SAN extension
     SanExtOnly,
-    /// Prefer SAN-based verification, but try the common name if the SAN is absent
+    /// Prefer SAN-based verification but try the common name if the SAN is absent
     SanOrCommonName,
     /// DANGER: Don't perform any name verification
     DisableNameVerification,
@@ -18,6 +18,6 @@ pub enum ClientNameVerification {
     None,
     /// Only verify the client's name from the SAN extension
     SanExtOnly(rustls::pki_types::ServerName<'static>),
-    /// Prefer SAN-based verification, but try the common name if the SAN is absent
+    /// Prefer SAN-based verification but try the common name if the SAN is absent
     SanOrCommonName(rustls::pki_types::ServerName<'static>),
 }

--- a/lib/src/pem.rs
+++ b/lib/src/pem.rs
@@ -1,4 +1,4 @@
-use webpki::types::PrivateKeyDer;
+use rustls_pki_types::PrivateKeyDer;
 
 pub(crate) fn read_certificates(
     path: &std::path::Path,

--- a/lib/src/self_signed.rs
+++ b/lib/src/self_signed.rs
@@ -71,6 +71,12 @@ impl SelfSignedVerifier {
     }
 }
 
+#[cfg(feature = "crypto-ring")]
+use rustls::crypto::ring::default_provider as default_crypto_provider;
+
+#[cfg(feature = "crypto-aws-lc-rs")]
+use rustls::crypto::aws_lc_rs::default_provider as default_crypto_provider;
+
 impl rustls::server::danger::ClientCertVerifier for SelfSignedVerifier {
     fn root_hint_subjects(&self) -> &[DistinguishedName] {
         self.subjects.as_slice()
@@ -96,7 +102,7 @@ impl rustls::server::danger::ClientCertVerifier for SelfSignedVerifier {
             message,
             cert,
             dss,
-            &rustls::crypto::aws_lc_rs::default_provider().signature_verification_algorithms,
+            &default_crypto_provider().signature_verification_algorithms,
         )
     }
 
@@ -110,12 +116,12 @@ impl rustls::server::danger::ClientCertVerifier for SelfSignedVerifier {
             message,
             cert,
             dss,
-            &rustls::crypto::aws_lc_rs::default_provider().signature_verification_algorithms,
+            &default_crypto_provider().signature_verification_algorithms,
         )
     }
 
     fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
-        rustls::crypto::aws_lc_rs::default_provider()
+        default_crypto_provider()
             .signature_verification_algorithms
             .supported_schemes()
     }
@@ -144,7 +150,7 @@ impl rustls::client::danger::ServerCertVerifier for SelfSignedVerifier {
             message,
             cert,
             dss,
-            &rustls::crypto::aws_lc_rs::default_provider().signature_verification_algorithms,
+            &default_crypto_provider().signature_verification_algorithms,
         )
     }
 
@@ -158,12 +164,12 @@ impl rustls::client::danger::ServerCertVerifier for SelfSignedVerifier {
             message,
             cert,
             dss,
-            &rustls::crypto::aws_lc_rs::default_provider().signature_verification_algorithms,
+            &default_crypto_provider().signature_verification_algorithms,
         )
     }
 
     fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
-        rustls::crypto::aws_lc_rs::default_provider()
+        default_crypto_provider()
             .signature_verification_algorithms
             .supported_schemes()
     }

--- a/lib/src/self_signed.rs
+++ b/lib/src/self_signed.rs
@@ -71,12 +71,6 @@ impl SelfSignedVerifier {
     }
 }
 
-#[cfg(feature = "crypto-ring")]
-use rustls::crypto::ring::default_provider as default_crypto_provider;
-
-#[cfg(feature = "crypto-aws-lc-rs")]
-use rustls::crypto::aws_lc_rs::default_provider as default_crypto_provider;
-
 impl rustls::server::danger::ClientCertVerifier for SelfSignedVerifier {
     fn root_hint_subjects(&self) -> &[DistinguishedName] {
         self.subjects.as_slice()
@@ -102,7 +96,7 @@ impl rustls::server::danger::ClientCertVerifier for SelfSignedVerifier {
             message,
             cert,
             dss,
-            &default_crypto_provider().signature_verification_algorithms,
+            &crate::default_crypto_provider().signature_verification_algorithms,
         )
     }
 
@@ -116,12 +110,12 @@ impl rustls::server::danger::ClientCertVerifier for SelfSignedVerifier {
             message,
             cert,
             dss,
-            &default_crypto_provider().signature_verification_algorithms,
+            &crate::default_crypto_provider().signature_verification_algorithms,
         )
     }
 
     fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
-        default_crypto_provider()
+        crate::default_crypto_provider()
             .signature_verification_algorithms
             .supported_schemes()
     }
@@ -150,7 +144,7 @@ impl rustls::client::danger::ServerCertVerifier for SelfSignedVerifier {
             message,
             cert,
             dss,
-            &default_crypto_provider().signature_verification_algorithms,
+            &crate::default_crypto_provider().signature_verification_algorithms,
         )
     }
 
@@ -164,12 +158,12 @@ impl rustls::client::danger::ServerCertVerifier for SelfSignedVerifier {
             message,
             cert,
             dss,
-            &default_crypto_provider().signature_verification_algorithms,
+            &crate::default_crypto_provider().signature_verification_algorithms,
         )
     }
 
     fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
-        default_crypto_provider()
+        crate::default_crypto_provider()
             .signature_verification_algorithms
             .supported_schemes()
     }

--- a/lib/src/self_signed.rs
+++ b/lib/src/self_signed.rs
@@ -96,7 +96,7 @@ impl rustls::server::danger::ClientCertVerifier for SelfSignedVerifier {
             message,
             cert,
             dss,
-            &rustls::crypto::ring::default_provider().signature_verification_algorithms,
+            &rustls::crypto::aws_lc_rs::default_provider().signature_verification_algorithms,
         )
     }
 
@@ -110,12 +110,12 @@ impl rustls::server::danger::ClientCertVerifier for SelfSignedVerifier {
             message,
             cert,
             dss,
-            &rustls::crypto::ring::default_provider().signature_verification_algorithms,
+            &rustls::crypto::aws_lc_rs::default_provider().signature_verification_algorithms,
         )
     }
 
     fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
-        rustls::crypto::ring::default_provider()
+        rustls::crypto::aws_lc_rs::default_provider()
             .signature_verification_algorithms
             .supported_schemes()
     }
@@ -144,7 +144,7 @@ impl rustls::client::danger::ServerCertVerifier for SelfSignedVerifier {
             message,
             cert,
             dss,
-            &rustls::crypto::ring::default_provider().signature_verification_algorithms,
+            &rustls::crypto::aws_lc_rs::default_provider().signature_verification_algorithms,
         )
     }
 
@@ -158,12 +158,12 @@ impl rustls::client::danger::ServerCertVerifier for SelfSignedVerifier {
             message,
             cert,
             dss,
-            &rustls::crypto::ring::default_provider().signature_verification_algorithms,
+            &rustls::crypto::aws_lc_rs::default_provider().signature_verification_algorithms,
         )
     }
 
     fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
-        rustls::crypto::ring::default_provider()
+        rustls::crypto::aws_lc_rs::default_provider()
             .signature_verification_algorithms
             .supported_schemes()
     }

--- a/lib/src/server.rs
+++ b/lib/src/server.rs
@@ -4,9 +4,9 @@ use rustls::server::danger::{ClientCertVerified, ClientCertVerifier};
 use rustls::server::WebPkiClientVerifier;
 use rustls::Error::General;
 use rustls::{CertificateError, DigitallySignedStruct, DistinguishedName, SignatureScheme};
+use rustls_pki_types::ServerName;
 use std::path::Path;
 use std::sync::Arc;
-use webpki::types::ServerName;
 
 use crate::{ClientNameVerification, Error, ProtocolVersions};
 
@@ -83,7 +83,7 @@ impl ClientNameVerifier {
 
         match end_entity_cert.verify_is_valid_for_subject_name(name) {
             Ok(()) => Ok(ClientCertVerified::assertion()),
-            Err(webpki::Error::CertNotValidForName) => {
+            Err(webpki::Error::CertNotValidForName(_)) => {
                 if use_common_name {
                     crate::common_name::verify_name_from_subject(cert, name)?;
                     Ok(ClientCertVerified::assertion())

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -4,10 +4,9 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
-[dev-dependencies]
-sfio-rustls-config = { path = "../lib" }
-rustls = "0.23"
-tokio-rustls = "0.26.0"
+[dependencies]
+sfio-rustls-config = { path = "../lib", default-features = false, features = ["crypto-ring"] }
+tokio-rustls = { version = "0.26", default-features = false, features = ["ring"] }
 tokio = { version = "1.35.0", features = ["test-util", "net", "rt", "macros"] }
 
 [[test]]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [dependencies]
-sfio-rustls-config = { path = "../lib", default-features = false, features = ["crypto-ring"] }
-tokio-rustls = { version = "0.26", default-features = false, features = ["ring"] }
+sfio-rustls-config = { path = "../lib", default-features = false, features = ["crypto-aws-lc-rs"] }
+tokio-rustls = { version = "0.26", default-features = false, features = ["aws_lc_rs"] }
 tokio = { version = "1.35.0", features = ["test-util", "net", "rt", "macros"] }
 
 [[test]]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 sfio-rustls-config = { path = "../lib", default-features = false, features = ["crypto-aws-lc-rs"] }
-tokio-rustls = { version = "0.26", default-features = false, features = ["aws_lc_rs"] }
+tokio-rustls = { version = "0.26", default-features = false, features = ["aws-lc-rs"] }
 tokio = { version = "1.35.0", features = ["test-util", "net", "rt", "macros"] }
 
 [[test]]

--- a/tests/src/test_verifiers.rs
+++ b/tests/src/test_verifiers.rs
@@ -1,4 +1,3 @@
-use rustls::ServerConfig;
 use sfio_rustls_config::{ClientNameVerification, ProtocolVersions, ServerNameVerification};
 use std::convert::TryInto;
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
@@ -6,6 +5,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::net::TcpStream;
 use tokio_rustls::rustls::pki_types::ServerName;
+use tokio_rustls::rustls::ServerConfig;
 use tokio_rustls::{TlsAcceptor, TlsConnector};
 
 fn certs_dir() -> PathBuf {


### PR DESCRIPTION
Fixes a regression in server name verification due to changes in rustls 0.23